### PR TITLE
Change the default for 'include' to None.

### DIFF
--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -422,6 +422,53 @@ class TestNestedNamespacedExposedProcess(AiidaTestCase):
             **{'e': Int(4)}
         )
 
+class TestIncludeExposeProcess(AiidaTestCase):
+
+    def setUp(self):
+        super(TestIncludeExposeProcess, self).setUp()
+
+        class SimpleProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(SimpleProcess, cls).define(spec)
+                spec.input('a', valid_type=Int, required=True)
+                spec.input('b', valid_type=Int, required=False)
+
+            @override
+            def _run(self, **kwargs):
+                pass
+
+        self.SimpleProcess = SimpleProcess
+
+    def test_include_none(self):
+        SimpleProcess = self.SimpleProcess
+
+        class ExposeProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(SimpleProcess, include=[])
+                spec.input('c', valid_type=Int, required=True)
+
+            @override
+            def _run(self, **kwargs):
+                SimpleProcess.run(a=Int(1), b=Int(2), **self.exposed_inputs(SimpleProcess))
+
+    def test_include_one(self):
+        SimpleProcess = self.SimpleProcess
+
+        class ExposeProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(SimpleProcess, include=['a'])
+                spec.input('c', valid_type=Int, required=True)
+
+            @override
+            def _run(self, **kwargs):
+                SimpleProcess.run(b=Int(2), **self.exposed_inputs(SimpleProcess))
+
+        ExposeProcess.run(**{'a': Int(1), 'c': Int(3)})
 
 class TestExcludeExposeProcess(AiidaTestCase):
 

--- a/aiida/work/process.py
+++ b/aiida/work/process.py
@@ -165,7 +165,7 @@ class ProcessSpec(plum.process.ProcessSpec):
 
         return template
 
-    def expose_inputs(self, process_class, namespace=None, exclude=(), include=()):
+    def expose_inputs(self, process_class, namespace=None, exclude=(), include=None):
         """
         This method allows one to automatically add the inputs from another
         Process to this ProcessSpec. The optional namespace argument can be
@@ -175,7 +175,7 @@ class ProcessSpec(plum.process.ProcessSpec):
         :param namespace: a namespace in which to place the exposed inputs
         :param exclude: list or tuple of input keys to exclude from being exposed
         """
-        if exclude and include:
+        if exclude and include is not None:
             raise ValueError('exclude and include are mutually exclusive')
 
         if namespace:
@@ -189,13 +189,12 @@ class ProcessSpec(plum.process.ProcessSpec):
             if name.startswith('_') or name == 'dynamic':
                 continue
 
-            if not exclude and not include:
-                port_namespace[name] = port
-            elif include and name in include:
-                port_namespace[name] = port
-            elif exclude and name not in exclude:
-                port_namespace[name] = port
-
+            if include is not None:
+                if name in include:
+                    port_namespace[name] = port
+            else:
+                if name not in exclude:
+                    port_namespace[name] = port
 
 class Process(plum.process.Process):
     """


### PR DESCRIPTION
The ``include`` is sematically different from ``exclude`` in that the default value is not really the same as an empty list. If ``include=[]``, I would expect nothing to be included, which is not the same as the default.

So here I change the default of ``include`` to ``None`` instead of an empty tuple, and explicitly check if it's ``None`` (no effect) or just empty (nothing included).