### PR TITLE
Exclude fails if the same inputname exists in the parent

### DIFF
--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -472,6 +472,21 @@ class TestExcludeExposeProcess(AiidaTestCase):
 
         self.assertRaises(ValueError, ExposeProcess.run, **{'b': Int(2), 'c': Int(3)})
 
+    def test_exclude_same_input_in_parent(self):
+        SimpleProcess = self.SimpleProcess
+
+        class ExposeProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(SimpleProcess, exclude=('a',))
+                spec.input('a', valid_type=Str)
+
+            @override
+            def _run(self, **kwargs):
+                SimpleProcess.run(a=Int(1), **self.exposed_inputs(SimpleProcess))
+
+        ExposeProcess.run(a=Str('1'), b=Int(2))
 
 class TestUnionInputsExposeProcess(AiidaTestCase):
 


### PR DESCRIPTION
If an input name that is given in `exclude` also exists in the parent, the `self.exposed_inputs` will still list this input. This is because in `exposed_inputs`, we just check if the corresponding input exists.

I think we really need to keep a lookup dict of which inputs actually *were* exposed, not rely on if they look like they were.

Some context: The reason I found this is because it caused a bug in one of my workchains, where the parent workchain takes an input, modifies it and then passes it on to the sub-workchain. It makes sense for them to be called the same, but caused this collision.

Also note: This PR is **expected to fail tests**, since it only contains a test that needs fixing before merging into `develop`.