### PR TITLE
Explicit lookup of exposed inputs

### DIFF
--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -472,6 +472,21 @@ class TestExcludeExposeProcess(AiidaTestCase):
 
         self.assertRaises(ValueError, ExposeProcess.run, **{'b': Int(2), 'c': Int(3)})
 
+    def test_exclude_same_input_in_parent(self):
+        SimpleProcess = self.SimpleProcess
+
+        class ExposeProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(SimpleProcess, exclude=('a',))
+                spec.input('a', valid_type=Str)
+
+            @override
+            def _run(self, **kwargs):
+                SimpleProcess.run(a=Int(1), **self.exposed_inputs(SimpleProcess))
+
+        ExposeProcess.run(a=Str('1'), b=Int(2))
 
 class TestUnionInputsExposeProcess(AiidaTestCase):
 

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -484,7 +484,7 @@ class TestExcludeExposeProcess(AiidaTestCase):
 
             @override
             def _run(self, **kwargs):
-                SimpleProcess.run(a=Int(1), **self.exposed_inputs(SimpleProcess))
+                SimpleProcess.run(a=Int(1), **self.exposed_inputs(SimpleProcess, agglomerate=False))
 
         ExposeProcess.run(a=Str('1'), b=Int(2))
 


### PR DESCRIPTION
This fixes the issue where the top-level `exclude` doesn't work if there's an input of the same name. The way this is done is by explicitly keeping track of which inputs have been exposed, and at which namespace level. 

The ``self._exposed_inputs`` is a nested dict, where the first nesting level has the namespace (or ``None``) as key, and the second level maps the ``process_class`` to a list of input names.