### PR TITLE
Incomplete 'expose_outputs' implementation.

### DIFF
--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -472,6 +472,21 @@ class TestExcludeExposeProcess(AiidaTestCase):
 
         self.assertRaises(ValueError, ExposeProcess.run, **{'b': Int(2), 'c': Int(3)})
 
+    def test_exclude_same_input_in_parent(self):
+        SimpleProcess = self.SimpleProcess
+
+        class ExposeProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_inputs(SimpleProcess, exclude=('a',))
+                spec.input('a', valid_type=Str)
+
+            @override
+            def _run(self, **kwargs):
+                SimpleProcess.run(a=Int(1), **self.exposed_inputs(SimpleProcess))
+
+        ExposeProcess.run(a=Str('1'), b=Int(2))
 
 class TestUnionInputsExposeProcess(AiidaTestCase):
 

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -484,7 +484,7 @@ class TestExcludeExposeProcess(AiidaTestCase):
 
             @override
             def _run(self, **kwargs):
-                SimpleProcess.run(a=Int(1), **self.exposed_inputs(SimpleProcess))
+                SimpleProcess.run(a=Int(1), **self.exposed_inputs(SimpleProcess, agglomerate=False))
 
         ExposeProcess.run(a=Str('1'), b=Int(2))
 

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -720,3 +720,41 @@ class TestNonAgglomerateExposeProcess(AiidaTestCase):
             },
         }
         self.ExposeProcess.run(**inputs)
+
+
+class TestExposeOutputProcess(AiidaTestCase):
+
+    def setUp(self):
+        super(TestExposeOutputProcess, self).setUp()
+
+        class SimpleProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(SimpleProcess, cls).define(spec)
+                spec.output('a', valid_type=Int, required=True)
+                spec.output('b', valid_type=Int, required=True)
+
+            @override
+            def _run(self, **kwargs):
+                self.out('a', Int(1))
+                self.out('b', Int(2))
+
+        self.SimpleProcess = SimpleProcess
+
+    def test_expose_outputs(self):
+        SimpleProcess = self.SimpleProcess
+
+        class ExposeProcess(Process):
+            @classmethod
+            def define(cls, spec):
+                super(ExposeProcess, cls).define(spec)
+                spec.expose_outputs(SimpleProcess)
+
+            @override
+            def _run(self, **kwargs):
+                instance = SimpleProcess.new_instance()
+                instance.run_until_complete()
+                self.out_many(**self.exposed_outputs(instance.calc, SimpleProcess))
+
+        result = ExposeProcess.run()
+        assert all(key in result for key in ['a', 'b'])

--- a/aiida/work/process.py
+++ b/aiida/work/process.py
@@ -282,6 +282,10 @@ class Process(plum.process.Process):
         else:
             return super(Process, self).out(output_port, value)
 
+    def out_many(self, **nodes):
+        for name, value in nodes.items():
+            self.out(name, value)
+
     @override
     def on_create(self, pid, inputs, saved_instance_state):
         from aiida.orm import load_node


### PR DESCRIPTION
Depends on #7.

This implements the basic functionality of `expose_outputs`, but is missing the namespace feature.

* Adds `out_many` to perform multiple `self.out` calls.
* The `exclude` and `include` logic is factored out into a `_filter_names` function, since it's used in both inputs and outputs
* The `exposed_outputs` function currently takes the `WorkCalculation` instance (because that's what you get when using `ToContext`), **and** the `Process` class. It would also be possible to look up the `Process` class from the calculation, but (as far as I'm aware) you can only do this via the name which introduces possible ambiguity.
* Also makes the `if name.startswith('_') or name == 'dynamic'` check before exposing, but I don't know if that's appropriate for outputs. If so, it could also go into the filter function.