### PR TITLE
Add tests for the inputs template

### DIFF
--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -229,6 +229,7 @@ class TestExposeProcess(AiidaTestCase):
                 SimpleProcess.run(**self.exposed_inputs(SimpleProcess, namespace='beta'))
 
         ExposeProcess.run(**{'a': Int(1), 'b': Int(2), 'beta': {'a': Int(3), 'b': Int(4)}})
+        ExposeProcess.spec().get_inputs_template()
 
     def test_expose_duplicate_namespaced(self):
         """
@@ -258,6 +259,7 @@ class TestExposeProcess(AiidaTestCase):
                 SimpleProcess.run(**self.exposed_inputs(SimpleProcess, namespace='beta'))
 
         ExposeProcess.run(**{'alef': {'a': Int(1), 'b': Int(2)}, 'beta': {'a': Int(3), 'b': Int(4)}})
+        ExposeProcess.spec().get_inputs_template()
 
     def test_expose_pass_same_dict(self):
         """
@@ -287,6 +289,7 @@ class TestExposeProcess(AiidaTestCase):
 
         sub_inputs = {'a': Int(1), 'b': Int(2)}
         ExposeProcess.run(**{'alef': sub_inputs, 'beta': sub_inputs})
+        ExposeProcess.spec().get_inputs_template()
 
 class TestNestedUnnamespacedExposedProcess(AiidaTestCase):
 
@@ -383,6 +386,9 @@ class TestNestedUnnamespacedExposedProcess(AiidaTestCase):
             **{'a': Int(0), 'b': Int(1), 'c': Int(2), 'd': Int(3), 'e': Int(4), 'f': Str(5)}
         )
 
+    def test_inputs_template(self):
+        self.BaseProcess.spec().get_inputs_template()
+        self.ParentProcess.spec().get_inputs_template
 
 class TestNestedNamespacedExposedProcess(AiidaTestCase):
 

--- a/aiida/work/process.py
+++ b/aiida/work/process.py
@@ -91,6 +91,10 @@ class PortNamespace(collections.MutableMapping, Port):
         self._ports = {}
 
     @property
+    def default(self):
+        return {name: port.default for name, port in self.ports.items()}
+
+    @property
     def ports(self):
         return self._ports
 


### PR DESCRIPTION
Exposing with a namespace breaks the ``spec().get_inputs_template()`` functionality. This is because ``get_inputs_template`` doesn't know how to handle ``PortNamespace`` objects (and it raises an error because they don't have a ``default``).

This PR adds a test for this, but it's not quite clear for me how to fix it. What should the input template of a namespace be? I'm assuming it should just have nested input templates for the namespace -- but is there a good way to build this?

**Update:** I added a ``default`` to the ``PortNamespace`` which is just a ``dict`` with key-value pairs of the port names and their respective defaults. Really not sure if that's the right way to do it, though.